### PR TITLE
Updated the submodule reference and fixed errors

### DIFF
--- a/Avalonia.HtmlRenderer.csproj
+++ b/Avalonia.HtmlRenderer.csproj
@@ -7,8 +7,12 @@
     <NoWarn>CS0436</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="external\Source\HtmlRenderer\Core\Utils\ImageError.png" />
-    <EmbeddedResource Include="external\Source\HtmlRenderer\Core\Utils\ImageLoad.png" />
+    <EmbeddedResource Include="external\Source\HtmlRenderer\Core\Utils\ImageError.png">
+      <LogicalName>TheArtOfDev.HtmlRenderer.Core.Utils.ImageError.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="external\Source\HtmlRenderer\Core\Utils\ImageLoad.png">
+      <LogicalName>TheArtOfDev.HtmlRenderer.Core.Utils.ImageLoad.png</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
     <ItemGroup>
     <Compile Include="Adapters\BrushAdapter.cs" />

--- a/HtmlLabel.cs
+++ b/HtmlLabel.cs
@@ -69,6 +69,7 @@ namespace Avalonia.Controls.Html
                     _htmlContainer.HtmlContainerInt.PerformLayout(ig);
                     var newSize = _htmlContainer.ActualSize;
                     constraint = new Size(newSize.Width + horizontal, newSize.Height + vertical);
+                    _htmlContainer.HtmlContainerInt.PageSize = _htmlContainer.HtmlContainerInt.ActualSize;
                 }
             }
 


### PR DESCRIPTION
Due to a PEBKAC, the submodule reference was incorrect. Additionally, updating the reference required some more fixes.