### PR TITLE
Migrating to Avalonia 0.10.0-preview1

### DIFF
--- a/Adapters/AvaloniaAdapter.cs
+++ b/Adapters/AvaloniaAdapter.cs
@@ -80,7 +80,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
             {
                 StartPoint = new RelativePoint(x, y, RelativeUnit.Relative), 
                 EndPoint = new RelativePoint(1 - x, 1 - y, RelativeUnit.Relative),
-                GradientStops = new[]
+                GradientStops = new GradientStops
                 {
                     new GradientStop(startColor, 0),
                     new GradientStop(endColor, 1)

--- a/Adapters/ControlAdapter.cs
+++ b/Adapters/ControlAdapter.cs
@@ -56,8 +56,9 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
         {
             get
             {
-                var pos = (_control.GetVisualRoot() as IInputRoot)?.MouseDevice?.Position ?? default(Point);
-                return Util.Convert(pos);
+                var pos = (_control.GetVisualRoot() as IInputRoot)?.MouseDevice?.Position;
+                //TODO: DPI
+                return Util.Convert(pos.Value.ToPointWithDpi(96));
             }
         }
 

--- a/Adapters/GraphicsAdapter.cs
+++ b/Adapters/GraphicsAdapter.cs
@@ -109,8 +109,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
         public override RSize MeasureString(string str, RFont font)
         {
             var text = GetText(str, font);
-            var measure = text.Measure();
-            return new RSize(measure.Width, measure.Height);
+            return new RSize(text.Bounds.Width, text.Bounds.Height);
             
         }
 
@@ -120,14 +119,15 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
             return new FormattedText
             {
                 Text = str,
-                Typeface = new Typeface(f.Name, font.Size, f.FontStyle, f.Weight),
+                Typeface = new Typeface(f.Name, f.FontStyle, f.Weight),
+                FontSize = font.Size
             };
         }
 
         public override void MeasureString(string str, RFont font, double maxWidth, out int charFit, out double charFitWidth)
         {
             var text = GetText(str, font);
-            var fullLength = text.Measure().Width;
+            var fullLength = text.Bounds.Width;
             if (fullLength < maxWidth)
             {
                 charFitWidth = fullLength;
@@ -140,7 +140,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
             BinarySearch(len =>
             {
                 text = GetText(str.Substring(0, len), font);
-                var size = text.Measure().Width;
+                var size = text.Bounds.Width;
                 lastMeasure = size;
                 lastLen = len;
                 if (size <= maxWidth)
@@ -151,7 +151,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
             if (lastMeasure > maxWidth)
             {
                 lastLen--;
-                lastMeasure = GetText(str.Substring(0, lastLen), font).Measure().Width;
+                lastMeasure = GetText(str.Substring(0, lastLen), font).Bounds.Width;
             }
             charFit = lastLen;
             charFitWidth = lastMeasure;
@@ -253,12 +253,14 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
 
         public override void DrawImage(RImage image, RRect destRect, RRect srcRect)
         {
-            _g.DrawImage(((ImageAdapter) image).Image, 1, Util.Convert(srcRect), Util.Convert(destRect));
+            _g.PushOpacity(1);
+            _g.DrawImage(((ImageAdapter)image).Image, Util.Convert(srcRect), Util.Convert(destRect));
         }
 
         public override void DrawImage(RImage image, RRect destRect)
         {
-            _g.DrawImage(((ImageAdapter) image).Image, 1, new Rect(0, 0, image.Width, image.Height),
+            _g.PushOpacity(1);
+            _g.DrawImage(((ImageAdapter)image).Image, new Rect(0, 0, image.Width, image.Height),
                 Util.Convert(destRect));
         }
 

--- a/Adapters/ImageAdapter.cs
+++ b/Adapters/ImageAdapter.cs
@@ -38,9 +38,9 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
         /// </summary>
         public Bitmap Image => _image;
 
-        public override double Width => _image.PixelWidth;
+        public override double Width => _image.PixelSize.Width;
 
-        public override double Height => _image.PixelHeight;
+        public override double Height => _image.PixelSize.Height;
 
         public override void Dispose()
         {

--- a/Adapters/PenAdapter.cs
+++ b/Adapters/PenAdapter.cs
@@ -27,12 +27,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
         /// </summary>
         private readonly IBrush _brush;
 
-        /// <summary>
-        /// the width of the pen
-        /// </summary>
-        private double _width;
-
-        private DashStyle _dashStyle;
+        private IDashStyle _dashStyle;
 
         /// <summary>
         /// the dash style of the pen
@@ -47,18 +42,17 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
             _brush = brush;
         }
 
-        public override double Width
-        {
-            get { return _width; }
-            set { _width = value; }
-        }
+        /// <summary>
+        ///   the width of the pen
+        /// </summary>
+        public override double Width { get; set; }
 
         public override RDashStyle DashStyle
         {
             set { DashStyles.TryGetValue(value, out _dashStyle); }
         }
 
-        private static readonly Dictionary<RDashStyle, DashStyle> DashStyles = new Dictionary<RDashStyle, DashStyle>
+        private static readonly Dictionary<RDashStyle, IDashStyle> DashStyles = new Dictionary<RDashStyle, IDashStyle>
         {
             {RDashStyle.Solid,null },
             {RDashStyle.Dash, global::Avalonia.Media.DashStyle.Dash },
@@ -72,8 +66,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia.Adapters
         /// </summary>
         public Pen CreatePen()
         {
-            var pen = new Pen(_brush, _width, _dashStyle);
-            return pen;
+            return new Pen(_brush, Width, _dashStyle);
         }
     }
 }

--- a/Avalonia.HtmlRenderer.csproj
+++ b/Avalonia.HtmlRenderer.csproj
@@ -111,6 +111,6 @@
     <Compile Include="Utilities\Util.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.6.1" />
+    <PackageReference Include="Avalonia" Version="0.10.0-preview1" />
   </ItemGroup>
 </Project>

--- a/HtmlControl.cs
+++ b/HtmlControl.cs
@@ -521,7 +521,7 @@ namespace Avalonia.Controls.Html
         /// <summary>
         /// Handle when dependency property value changes to update the underline HtmlContainer with the new value.
         /// </summary>
-        private static void OnAvaloniaProperty_valueChanged(AvaloniaObject AvaloniaObject,
+        private static void OnAvaloniaProperty_valueChanged(IAvaloniaObject AvaloniaObject,
             AvaloniaPropertyChangedEventArgs e)
         {
             var control = AvaloniaObject as HtmlControl;

--- a/HtmlLabel.cs
+++ b/HtmlLabel.cs
@@ -82,7 +82,7 @@ namespace Avalonia.Controls.Html
         /// <summary>
         /// Handle when dependency property value changes to update the underline HtmlContainer with the new value.
         /// </summary>
-        private static void OnAvaloniaProperty_valueChanged(AvaloniaObject AvaloniaObject, AvaloniaPropertyChangedEventArgs e)
+        private static void OnAvaloniaProperty_valueChanged(IAvaloniaObject AvaloniaObject, AvaloniaPropertyChangedEventArgs e)
         {
             var control = AvaloniaObject as HtmlLabel;
             if (control != null)

--- a/PropertyHelper.cs
+++ b/PropertyHelper.cs
@@ -9,7 +9,7 @@ namespace Avalonia.HtmlRenderer
     static class PropertyHelper
     {
 
-        public static AvaloniaProperty Register<TOwner, T>(string name, T def, Action<AvaloniaObject, AvaloniaPropertyChangedEventArgs> changed) where TOwner : AvaloniaObject
+        public static AvaloniaProperty Register<TOwner, T>(string name, T def, Action<IAvaloniaObject, AvaloniaPropertyChangedEventArgs> changed) where TOwner : AvaloniaObject
         {
             var pp = AvaloniaProperty.Register<TOwner, T>(name, def);
             Action<AvaloniaPropertyChangedEventArgs> cb = args =>


### PR DESCRIPTION
This PR is based on https://github.com/AvaloniaUI/Avalonia.HtmlRenderer/pull/5 and will allow you to use the library in your project targeting Avalonia `0.10.0-preview1`.
I took @pr8x's changes and added my changes on top. I am not very familiar with Avalonia yet and I don't expect these changes to be merged, but I hope it will save some time for the next person trying to integrate `Avalonia.HtmlRenderer` into their project.