### PR TITLE
Enable Text property to act as Content

### DIFF
--- a/Source/Avalonia.HtmlRenderer/HtmlControl.cs
+++ b/Source/Avalonia.HtmlRenderer/HtmlControl.cs
@@ -18,6 +18,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
+using Avalonia.Metadata;
 using Avalonia.Threading;
 using TheArtOfDev.HtmlRenderer.Core;
 using TheArtOfDev.HtmlRenderer.Core.Entities;
@@ -273,6 +274,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia
         /// Gets or sets the text of this panel
         /// </summary>
         [Description("Sets the html of this control.")]
+        [Content]
         public string Text
         {
             get { return (string)GetValue(TextProperty); }


### PR DESCRIPTION
This is useful to easily use html snippets in xaml:

```xaml
    <htm:HtmlLabel>
      <![CDATA[
        <p><b>Hello <u>World</u></b></p>
        <p><i>This is a Sample Paragraph</i> in html coming from CDATA section</p>
      ]]>
    </htm:HtmlLabel>
```