### PR TITLE
HTML Entity support for word-break:break-all

### DIFF
--- a/Source/HtmlRenderer/Core/Parse/HtmlParser.cs
+++ b/Source/HtmlRenderer/Core/Parse/HtmlParser.cs
@@ -81,7 +81,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Parse
                 if (!endText.Span.IsEmptyOrWhitespace())
                 {
                     var abox = CssBox.CreateBox(root);
-                    abox.Text = endText;
+                    abox.Text = HtmlUtils.DecodeHtml(endText.ToString()).AsMemory();
                 }
             }
 
@@ -106,7 +106,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Parse
             if (!text.IsEmpty)
             {
                 var abox = CssBox.CreateBox(curBox);
-                abox.Text = text;
+                abox.Text = HtmlUtils.DecodeHtml(text.ToString()).AsMemory();
             }
         }
 

--- a/Source/HtmlRenderer/Core/Utils/HtmlUtils.cs
+++ b/Source/HtmlRenderer/Core/Utils/HtmlUtils.cs
@@ -40,6 +40,8 @@ namespace TheArtOfDev.HtmlRenderer.Core.Utils
             new KeyValuePair<string, string>("&gt;", ">"),
             new KeyValuePair<string, string>("&quot;", "\""),
             new KeyValuePair<string, string>("&amp;", "&"),
+            new KeyValuePair<string, string>("&nbsp;", " "),
+            new KeyValuePair<string, string>("&apos;", "\'")
         };
 
         /// <summary>


### PR DESCRIPTION
This fixes a bug when using `word-break: break-all` where HTML Special Entities were not being decoded. 

The change decodes all HTML Special Entities during initial parsing in `HtmlParser.ParseDocument` so `ParseToWords` technically doesn't need to decode them anymore but this works around the special cases there for `WordBreak == CssConstants.BreakAll`.

Also included `/` and ` ` entities for decoding.