### PR TITLE
Fix nowrap not working with other child CSS Boxes

### DIFF
--- a/Source/HtmlRenderer/Core/Dom/CssLayoutEngine.cs
+++ b/Source/HtmlRenderer/Core/Dom/CssLayoutEngine.cs
@@ -248,6 +248,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
             var localMaxRight = maxRight;
             var localmaxbottom = maxbottom;
 
+            var i = 0;
             foreach (CssBox b in box.Boxes)
             {
                 double leftspacing = (b.Position != CssConstants.Absolute && b.Position != CssConstants.Fixed) ? b.ActualMarginLeft + b.ActualBorderLeftWidth + b.ActualPaddingLeft : 0;
@@ -264,8 +265,21 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                     if (b.WhiteSpace == CssConstants.NoWrap && curx > startx)
                     {
                         var boxRight = curx;
-                        foreach (var word in b.Words)
-                            boxRight += word.FullWidth;
+
+                        void HandleBox(CssBox currBox)
+                        {
+                            foreach (var word in currBox.Words)
+                                boxRight += word.FullWidth;
+                            foreach (var subBox in currBox.Boxes)
+                            {
+                                HandleBox(subBox);
+                            }
+                        }
+
+                        for (int j = i; j < box.Boxes.Count; j++)
+                        {
+                            HandleBox(box.Boxes[j]);
+                        }
                         if (boxRight > limitRight)
                             wrapNoWrapBox = true;
                     }
@@ -327,6 +341,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                 }
 
                 curx += rightspacing;
+                i++;
             }
 
             // handle height setting


### PR DESCRIPTION
The issue this is attempting to resolve is that if you have a nowrap span that contains sections with different spans inside, the text still ends up wrapping between the spans.

Here is a sample that can run from the demo project to demonstrate the issue:
```
<html>
    <head>
        <title>Intro</title>
        <link rel="Stylesheet" href="StyleSheet" />
    </head>
    <body style="background-color: #333; background-gradient: #707; background-gradient-angle: 60; margin: 0;">
        <h1 align="center" style="color: white">
            HTML Renderer Project - $$Platform$$
            <br />
            <span style="font-size: x-small;">Release $$Release$$</span>
        </h1>
        <blockquote class="whitehole">
            <p>abcdefrthrwehrtwhert <span style="white-space: nowrap">g <b>hijsdgfhsghk</b> efagkjehrwb</span> qelrkjhfbnq3rlejkfbjklqerbflkjblkjl</p>
        </blockquote>
    </body>
</html>
```

Before fix:
![image](https://github.com/user-attachments/assets/e69e9838-caad-4913-82d6-c3e5cd70ede5)


After fix:
![image](https://github.com/user-attachments/assets/c6f52dce-0698-47f6-8668-bec98a4fa20b)
