### PR TITLE
Measure box words before attempting to use FullWidth.

### DIFF
--- a/Source/HtmlRenderer/Core/Dom/CssLayoutEngine.cs
+++ b/Source/HtmlRenderer/Core/Dom/CssLayoutEngine.cs
@@ -268,12 +268,11 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
 
                         void HandleBox(CssBox currBox)
                         {
+                            currBox.MeasureWordsSize(g);
                             foreach (var word in currBox.Words)
                                 boxRight += word.FullWidth;
                             foreach (var subBox in currBox.Boxes)
-                            {
                                 HandleBox(subBox);
-                            }
                         }
 
                         for (int j = i; j < box.Boxes.Count; j++)


### PR DESCRIPTION
This is an addendum to my previous PR #63. I did not realize that at this point the size of the words in all boxes aren't measured yet. The reason it worked before was that I was testing on desktop by resizing the window, so the wrapping code would run multiple times and would work on the second run. After running on mobile, I noticed that the wrapping was not working since the FullWidth property of the words in the next box would return NaN. Therefore, I found that I just need to make sure that MeasureWordsSize gets run on any boxes before inspecting their word widths.