### PR TITLE
Fix: Correct property assigned in BorderBrush setter

### DIFF
--- a/src/Avalonia.HtmlRenderer/HtmlControl.cs
+++ b/src/Avalonia.HtmlRenderer/HtmlControl.cs
@@ -299,7 +299,7 @@ namespace TheArtOfDev.HtmlRenderer.Avalonia
         public IBrush BorderBrush
         {
             get { return (IBrush)GetValue(BorderBrushProperty); }
-            set { SetValue(BorderThicknessProperty, value); }
+            set { SetValue(BorderBrushProperty, value); }
         }
 
         public Thickness Padding


### PR DESCRIPTION
### Description
This PR fixes a typo in the `BorderBrush` property setter. 

Previously, the setter was incorrectly assigning the brush value to `BorderThicknessProperty`. This PR updates it to correctly use `BorderBrushProperty`.

### Changes Made
* Updated `BorderBrush` setter in `Avalonia.HtmlRenderer` to call `SetValue(BorderBrushProperty, value)`.